### PR TITLE
Return false from `isAuthenticated` in case of an exception.

### DIFF
--- a/lib/plugins/auth0.ts
+++ b/lib/plugins/auth0.ts
@@ -86,7 +86,11 @@ class AuthAdapter {
   async isAuthenticated(): Promise<boolean> {
     const auth = await this.getAuthClient();
     console.log('checking if authenticated');
-    return auth?.isAuthenticated();
+    try {
+      return auth ? auth.isAuthenticated() : false;
+    } catch (e) {
+      return false;
+    }
   }
 
   /* called from the login page to authenticate the user */


### PR DESCRIPTION
It's not expected for `isAuthenticated` to throw an exception, but Auth0 may do it.